### PR TITLE
Add site_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ markdown_extensions:
 repo_url: https://github.com/onc-healthit/api-resource-guide
 repo_name: onc-healthit/api-resource-guide
 edit_uri: edit/main/docs/
+site_url: https://onc-healthit.github.io/api-resource-guide/
 plugins:
   - git-revision-date-localized
   - search


### PR DESCRIPTION
Following this documentation: https://www.mkdocs.org/user-guide/configuration/#site_url

This is useful because now when you run `mkdocs serve` locally you'll have a URL path that mimics the deployed version.

Right now this is useful to me because I'm trying to link to the Privacy Policy in the footer and before adding this `site_url` the link would not work when I both locally serve the docs and deploy to GitHub pages. But now the local deployment will mimic what gets deployed to GitHub pages.